### PR TITLE
Add preliminary IPXACT parameter support.

### DIFF
--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -37,8 +37,7 @@ case object FFTSize extends Field[Int]
 class DspConfig extends Config(
   (pname, site, here) => pname match {
     case BuildDSP => { (q: Parameters) => {
-      implicit val p = q
-      Module(new FFTWrapper[DspReal])
+      Module(new FFTWrapper[DspReal]()(DspRealRealImpl, q))
     }}
     case FFTSize => 8
     case FFTKey => { (q: Parameters) => { 

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -31,6 +31,8 @@ trait HasIPXACTParameters {
   def getIPXACTParameters: Map[String, String]
 }
 
+case object FFTSize extends Field[Int]
+
 // create a new DSP Configuration
 class DspConfig extends Config(
   (pname, site, here) => pname match {
@@ -38,9 +40,10 @@ class DspConfig extends Config(
       implicit val p = q
       Module(new FFTWrapper[DspReal])
     }}
+    case FFTSize => 8
     case FFTKey => { (q: Parameters) => { 
       implicit val p = q
-      FFTConfig[DspReal](n = 8)
+      FFTConfig[DspReal](n = site(FFTSize))
     }}
     //NastiId => "FFT"
 	  case NastiKey => NastiParameters(64, 32, 1)
@@ -75,9 +78,6 @@ class DspConfig extends Config(
     val parameterList = List[Field[_]](TLId, PAddrBits)
     val parameterMap = parameterList.foldLeft(Map[String, String]()) { (m, s) => m(s.toString) = params(s).toString; m }
 
-    // Conjure up some IPXACT synthsized parameters.
-    parameterMap ++= List(("IsComplex", "0"), ("IsSigned", "1"))
-
     // Get some nested parameters.
     val (nastiDataBits, nastiAddrBits, nastiIdBits) = params(NastiKey) match {
       case NastiParameters(d: Int, a: Int, i: Int) => (d, a, i)
@@ -99,6 +99,11 @@ class DspConfig extends Config(
     ) => (nManagers.toString, dataBits)
     }
     parameterMap ++= List(("nManagers", nManagers.toString), ("dataBits", dataBits.toString))
+
+    // Conjure up some IPXACT synthsized parameters.
+    val fftSize = params(FFTSize)
+    parameterMap ++= List(("IsComplex", "0"), ("IsSigned", "1"), ("FFTSize", fftSize.toString))
+
     parameterMap
   }
 }

--- a/src/main/scala/Generator.scala
+++ b/src/main/scala/Generator.scala
@@ -1,7 +1,7 @@
 package fft
 
 import util.GeneratorApp
-import org.accellera.spirit.v1685_2009.{File => SpiritFile, _}
+import org.accellera.spirit.v1685_2009.{File => SpiritFile, Parameters => SpiritParameters, _}
 import javax.xml.bind.{JAXBContext, Marshaller}
 import java.io.{File, FileOutputStream}
 import scala.collection.JavaConverters
@@ -155,6 +155,21 @@ trait DspGeneratorApp extends GeneratorApp {
     fileSets
   }
 
+  def makeParameters(factory: ObjectFactory): SpiritParameters = {
+    val parameters = new SpiritParameters()
+    val config = new DspConfig()
+    for ( (name, value) <- config.getIPXACTParameters) {
+      println("parameter: %s, value: %s".format(name, value))
+      val nameValuePairType = new NameValuePairType
+      nameValuePairType.setName(name)
+      val nameValuePairTypeValue = new NameValuePairType.Value
+      nameValuePairTypeValue.setValue(value)
+      nameValuePairType.setValue(nameValuePairTypeValue)
+      parameters.getParameter().add(nameValuePairType)
+    }
+    parameters
+  }
+
   def generateIPXact {
     val bits_in = params(DspBlockKey).inputWidth
     val bits_out = params(DspBlockKey).outputWidth
@@ -185,6 +200,7 @@ trait DspGeneratorApp extends GeneratorApp {
     componentType.setBusInterfaces(busInterfaces)
     componentType.setModel(model)
     componentType.setFileSets(makeFileSets(factory))
+    componentType.setParameters(makeParameters(factory))
 
     val component = factory.createComponent(componentType)
 

--- a/src/main/scala/Generator.scala
+++ b/src/main/scala/Generator.scala
@@ -13,6 +13,8 @@ import cde.Parameters
 import dsptools.junctions._
 import dsptools._
 
+class NastiConfig(implicit val p: Parameters) extends HasNastiParameters {}
+
 // includes IPXact generation
 trait DspGeneratorApp extends GeneratorApp {
 
@@ -39,13 +41,63 @@ trait DspGeneratorApp extends GeneratorApp {
     portmaps
   }
 
-  def makeAXIPortMaps(prefix: String): BusInterfaceType.PortMaps = {
+  def makeAXIStreamPortMaps(prefix: String): BusInterfaceType.PortMaps = {
     makePortMaps(Seq(
       "ACLK"     -> "clock",
       "ARESETn"  -> "reset",
       "TVALID"   -> s"${prefix}_valid",
       "TLAST"    -> s"${prefix}_sync",
       "TDATA"    -> s"${prefix}_bits"))
+  }
+
+  def makeAXIPortMaps(prefix: String): BusInterfaceType.PortMaps = {
+    makePortMaps(Seq(
+      "ACLK"     -> "clock",
+      "ARESETn"  -> "reset",
+      "ARVALID"  -> s"${prefix}_ar_valid",
+      "ARREADY"  -> s"${prefix}_ar_ready",
+      "ARID"     -> s"${prefix}_ar_bits_id",
+      "ARADDR"   -> s"${prefix}_ar_bits_addr",
+      "ARSIZE"   -> s"${prefix}_ar_bits_size",
+      "ARLEN"    -> s"${prefix}_ar_bits_len",
+      "ARBURST"  -> s"${prefix}_ar_bits_burst",
+      "ARPROT"   -> s"${prefix}_ar_bits_prot",
+      "ARLOCK"   -> s"${prefix}_ar_bits_lock",
+      "ARQOS"    -> s"${prefix}_ar_bits_qos",
+      "ARREGION" -> s"${prefix}_ar_bits_region",
+      "ARCACHE"  -> s"${prefix}_ar_bits_cache",
+      "ARUSER"   -> s"${prefix}_ar_bits_user",
+      "AWVALID"  -> s"${prefix}_aw_valid",
+      "AWREADY"  -> s"${prefix}_aw_ready",
+      "AWID"     -> s"${prefix}_aw_bits_id",
+      "AWADDR"   -> s"${prefix}_aw_bits_addr",
+      "AWSIZE"   -> s"${prefix}_aw_bits_size",
+      "AWLEN"    -> s"${prefix}_aw_bits_len",
+      "AWBURST"  -> s"${prefix}_aw_bits_burst",
+      "AWPROT"   -> s"${prefix}_aw_bits_prot",
+      "AWLOCK"   -> s"${prefix}_aw_bits_lock",
+      "AWQOS"    -> s"${prefix}_aw_bits_qos",
+      "AWREGION" -> s"${prefix}_aw_bits_region",
+      "AWCACHE"  -> s"${prefix}_aw_bits_cache",
+      "AWUSER"   -> s"${prefix}_aw_bits_user",
+      "WVALID"   -> s"${prefix}_w_valid",
+      "WREADY"   -> s"${prefix}_w_ready",
+      "WDATA"    -> s"${prefix}_w_bits_data",
+      "WSTRB"    -> s"${prefix}_w_bits_strb",
+      "WLAST"    -> s"${prefix}_w_bits_last",
+      "WUSER"    -> s"${prefix}_w_bits_user",
+      "RVALID"   -> s"${prefix}_r_valid",
+      "RREADY"   -> s"${prefix}_r_ready",
+      "RID"      -> s"${prefix}_r_bits_id",
+      "RRESP"    -> s"${prefix}_r_bits_resp",
+      "RDATA"    -> s"${prefix}_r_bits_data",
+      "RLAST"    -> s"${prefix}_r_bits_last",
+      "RUSER"    -> s"${prefix}_r_bits_user",
+      "BVALID"   -> s"${prefix}_b_valid",
+      "BREADY"   -> s"${prefix}_b_ready",
+      "BID"      -> s"${prefix}_b_bits_id",
+      "BRESP"    -> s"${prefix}_b_bits_resp",
+      "BUSER"    -> s"${prefix}_b_bits_user"))
   }
 
   def makePort(name: String, direction: Boolean, width: Int): PortType = {
@@ -71,7 +123,7 @@ trait DspGeneratorApp extends GeneratorApp {
     port
   }
 
-  def makeAXIPorts(prefix: String, direction: Boolean, bits: Int): Seq[PortType] = {
+  def makeAXIStreamPorts(prefix: String, direction: Boolean, bits: Int): Seq[PortType] = {
     val ports = Seq(
       ("valid", direction, 1),
       ("sync", direction, 1),
@@ -81,14 +133,67 @@ trait DspGeneratorApp extends GeneratorApp {
       makePort(s"${prefix}_${name}", portdir, width) }
   }
 
+  def makeAXIPorts(prefix: String, direction: Boolean, config: HasNastiParameters): Seq[PortType] = {
+    val ports = Seq(
+      ("ar_valid", direction, 1),
+      ("ar_ready", !direction, 1),
+      ("ar_bits_id", direction, config.nastiXIdBits),
+      ("ar_bits_addr", direction, config.nastiXAddrBits),
+      ("ar_bits_size", direction, config.nastiXSizeBits),
+      ("ar_bits_len", direction, config.nastiXLenBits),
+      ("ar_bits_burst", direction, config.nastiXBurstBits),
+      ("ar_bits_lock", direction, 1),
+      ("ar_bits_cache", direction, config.nastiXCacheBits),
+      ("ar_bits_prot", direction, config.nastiXProtBits),
+      ("ar_bits_qos", direction, config.nastiXQosBits),
+      ("ar_bits_region", direction, config.nastiXRegionBits),
+      ("ar_bits_user", direction, config.nastiXUserBits),
+      ("aw_valid", direction, 1),
+      ("aw_ready", !direction, 1),
+      ("aw_bits_id", direction, config.nastiXIdBits),
+      ("aw_bits_addr", direction, config.nastiXAddrBits),
+      ("aw_bits_size", direction, config.nastiXSizeBits),
+      ("aw_bits_len", direction, config.nastiXLenBits),
+      ("aw_bits_burst", direction, config.nastiXBurstBits),
+      ("aw_bits_lock", direction, 1),
+      ("aw_bits_cache", direction, config.nastiXCacheBits),
+      ("aw_bits_prot", direction, config.nastiXProtBits),
+      ("aw_bits_qos", direction, config.nastiXQosBits),
+      ("aw_bits_region", direction, config.nastiXRegionBits),
+      ("aw_bits_user", direction, config.nastiXUserBits),
+      ("w_valid", direction, 1),
+      ("w_ready", !direction, 1),
+      ("w_bits_data", direction, config.nastiXDataBits),
+      ("w_bits_strb", direction, config.nastiWStrobeBits),
+      ("w_bits_last", direction, 1),
+      ("w_bits_user", direction, config.nastiXUserBits),
+      ("r_valid", !direction, 1),
+      ("r_ready", direction, 1),
+      ("r_bits_id", !direction, config.nastiXIdBits),
+      ("r_bits_resp", !direction, config.nastiXRespBits),
+      ("r_bits_data", !direction, config.nastiXDataBits),
+      ("r_bits_last", !direction, 1),
+      ("r_bits_user", !direction, config.nastiXUserBits),
+      ("b_valid", !direction, 1),
+      ("b_ready", direction, 1),
+      ("b_bits_id", !direction, config.nastiXIdBits),
+      ("b_bits_resp", !direction, config.nastiXRespBits),
+      ("b_bits_user", !direction, config.nastiXUserBits))
+
+    ports.sorted.map { case (name, portdir, width) =>
+      makePort(s"${prefix}_${name}", portdir, width) }
+  }
+
   def makeAllPorts(bits_in: Int, bits_out: Int): ModelType.Ports = {
-    val inPorts = makeAXIPorts(s"io_in", false, bits_in)
-    val outPorts = makeAXIPorts(s"io_out", true, bits_out)
+    val config = new NastiConfig()(params)
+    val streamInPorts = makeAXIStreamPorts(s"io_in", false, bits_in)
+    val streamOutPorts = makeAXIStreamPorts(s"io_out", true, bits_out)
+    val axiInPorts = makeAXIPorts(s"io_axi", false, config)
     val globalPorts = Seq(
       makePort("clock", false, 1),
       makePort("reset", false, 1))
     val ports = new ModelType.Ports
-    ports.getPort().addAll(toCollection(globalPorts ++ inPorts ++ outPorts))
+    ports.getPort().addAll(toCollection(globalPorts ++ streamInPorts ++ streamOutPorts ++ axiInPorts))
     ports
   }
 
@@ -105,7 +210,7 @@ trait DspGeneratorApp extends GeneratorApp {
     abstractionType.setName("AXI4_rtl")
     abstractionType.setVersion("r0p0_0")
 
-    val portMaps = makeAXIPortMaps(s"io_in")
+    val portMaps = makeAXIStreamPortMaps(s"io_in")
 
     val busif = new BusInterfaceType
     busif.setName(s"io_in")
@@ -128,7 +233,7 @@ trait DspGeneratorApp extends GeneratorApp {
     abstractionType.setName("AXI4_rtl")
     abstractionType.setVersion("r0p0_0")
 
-    val portMaps = makeAXIPortMaps(s"io_out")
+    val portMaps = makeAXIStreamPortMaps(s"io_out")
 
     val busif = new BusInterfaceType
     busif.setName(s"io_out")
@@ -136,6 +241,76 @@ trait DspGeneratorApp extends GeneratorApp {
     busif.setAbstractionType(abstractionType)
     busif.setPortMaps(portMaps)
     busif
+  }
+
+  def makeAXIInterface: BusInterfaceType = {
+    val busType = new LibraryRefType
+    busType.setVendor("amba.com")
+    busType.setLibrary("AMBA4")
+    busType.setName("AXI4")
+    busType.setVersion("r0p0_0")
+
+    val abstractionType = new LibraryRefType
+    abstractionType.setVendor("amba.com")
+    abstractionType.setLibrary("AMBA4")
+    abstractionType.setName("AXI4_rtl")
+    abstractionType.setVersion("r0p0_0")
+
+    val addrSpaceRef = new BusInterfaceType.Master.AddressSpaceRef
+    addrSpaceRef.setAddressSpaceRef(s"s_as")
+
+    val master = new BusInterfaceType.Master
+    master.setAddressSpaceRef(addrSpaceRef)
+
+    val portMaps = makeAXIPortMaps(s"io_axi")
+
+    val busif = new BusInterfaceType
+    busif.setName(s"io_axi")
+    busif.setBusType(busType)
+    busif.setAbstractionType(abstractionType)
+    busif.setPortMaps(portMaps)
+    busif
+  }
+
+  def makeAddressSpace(name: String, size: Long): AddressSpaces.AddressSpace = {
+    val addressSpace = new AddressSpaces.AddressSpace
+    addressSpace.setName(name)
+    var range = new BankedBlockType.Range
+    range.setValue("0x" + size.toHexString)
+    addressSpace.setRange(range)
+    var width = new BankedBlockType.Width
+    width.setValue(BigInteger.valueOf(32))
+    addressSpace.setWidth(width)
+    addressSpace.setAddressUnitBits(BigInteger.valueOf(8))
+    addressSpace
+  }
+
+  def makeMemoryMap(name: String, baseAddr: BigInt): MemoryMapType = {
+    // Generate the subspaceMaps, one for each baseAddress.
+    val memoryMap = new MemoryMapType
+    val addrBlocks = memoryMap.getMemoryMap()
+    memoryMap.setName(name)
+    val addrBlockMap = new AddressBlockType
+    addrBlockMap.setName("dut")
+    val baseAddress = new BaseAddress
+    baseAddress.setValue("0x" + baseAddr.toString(16))
+    addrBlockMap.setBaseAddress(baseAddress)
+    val registers = addrBlockMap.getRegister()
+    
+    val scrMap = testchipip.SCRAddressMap.contents.head._2
+    scrMap.foreach { case(scrName, scrOffset) => 
+      val register = new RegisterFile.Register
+      register.setName(scrName)
+      register.setAddressOffset("0x" + scrOffset.toString(16))
+      val size = new RegisterFile.Register.Size
+      size.setValue(new BigInteger("64"))
+      register.setSize(size)
+      registers.add(register)
+    }
+    addrBlocks.add(addrBlockMap)
+
+    memoryMap.setAddressUnitBits(BigInteger.valueOf(8))
+    memoryMap
   }
 
   def makeFileSets(factory: ObjectFactory): FileSets = {
@@ -176,7 +351,14 @@ trait DspGeneratorApp extends GeneratorApp {
     val factory = new ObjectFactory
 
     val busInterfaces = new BusInterfaces
-    busInterfaces.getBusInterface().addAll(toCollection(Seq(makeInputInterface, makeOutputInterface)))
+    busInterfaces.getBusInterface().addAll(toCollection(Seq(makeInputInterface, makeOutputInterface, makeAXIInterface)))
+
+    //val addressSpaces = new AddressSpaces
+    //addressSpaces.getAddressSpace.addAll(toCollection(
+    //  (0 until nOutputs).map(i => makeAddressSpace(s"s${i}_as", regionSize))
+    //))
+    val memoryMaps = new MemoryMaps
+    memoryMaps.getMemoryMap().add(makeMemoryMap("mm", BigInt(0)))
 
     val model = new ModelType
     val views = new ModelType.Views
@@ -198,6 +380,8 @@ trait DspGeneratorApp extends GeneratorApp {
     componentType.setVendor("edu.berkeley.cs")
     componentType.setVersion("1.0")
     componentType.setBusInterfaces(busInterfaces)
+    //componentType.setAddressSpaces(addressSpaces)
+    componentType.setMemoryMaps(memoryMaps)
     componentType.setModel(model)
     componentType.setFileSets(makeFileSets(factory))
     componentType.setParameters(makeParameters(factory))

--- a/src/main/scala/Top.scala
+++ b/src/main/scala/Top.scala
@@ -30,7 +30,7 @@ class DspTop(p: Parameters) extends LazyModule {
   override lazy val module = Module(new DspTopModule(p, this, new DspTopBundle(p)))
 }
 
-class DspTopBundle(p: Parameters) extends DspBlockIO()(p) {}
+class DspTopBundle(p: Parameters) extends BasicDspBlockIO()(p) {}
 
 class DspTopModule[+L <: DspTop, +B <: DspTopBundle](val p: Parameters, l: L, b: => B)
   extends LazyModuleImp(l) with DspModule {
@@ -41,6 +41,6 @@ class DspTopModule[+L <: DspTop, +B <: DspTopBundle](val p: Parameters, l: L, b:
 case object BuildDSP extends Field[(Parameters) => DspBlock]
 
 trait DspModule {
-  implicit val p: Parameters
+  val p: Parameters
   val module = p(BuildDSP)(p)
 }


### PR DESCRIPTION
The getIPXACTParameters() method contains example IPXACT parameters. They should be updated to match the real (desired) parameter collection.

We should use the "one-true" DspConfig object instead of creating our own.